### PR TITLE
Handle .touchCancel UIControl event

### DIFF
--- a/Sources/DSFStepperView/private/DSFDelayedRepeatingButton.swift
+++ b/Sources/DSFStepperView/private/DSFDelayedRepeatingButton.swift
@@ -204,7 +204,7 @@ internal class DSFDelayedRepeatingButton: UIButton {
 
 	private func setup() {
 		self.addTarget(self, action: #selector(startPress), for: .touchDown)
-		self.addTarget(self, action: #selector(endPress), for: [.touchUpOutside, .touchUpInside])
+        self.addTarget(self, action: #selector(endPress), for: [.touchUpOutside, .touchUpInside, .touchCancel])
 	}
 
 	@objc func startPress(_ sender: Any?) {


### PR DESCRIPTION
Cancelling the touch on the button can cause `endPress` not to get called and the timer will keep firing forever.

Steps to repro:

- begin a long press on the increment or decrement button
- slide your finger off of the button while the timer is firing repeatedly

Expected:

- the timer stops firing

Actual:

- the timer continues to fire, endlessly incrementing or decrementing the stepper value